### PR TITLE
11.16 bumb the dummy endpoint version number

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,7 +5,7 @@ const app = express()
 const PORT = process.env.PORT || 5000
 
 app.get('/version', (req, res) => {
-  res.send('1.0.9') // change to ensure new version deploy
+  res.send('1.0.10') // change to ensure new version deploy
 })
 
 app.get('/health', (req, res) => {


### PR DESCRIPTION
Ex11.16 testing a pull request with commits without #skip but the merge commit having #skip.