### PR TITLE
Ex11.19 scheduled action

### DIFF
--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -19,3 +19,21 @@ jobs:
           url: ${{ vars.RENDER_DEPLOYED_URL }}/health
           max-attempts: 5
           retry-delay: 15s
+      - name: Notify succesfull build and test action
+        if: ${{ success() }}
+        uses: rjstone/discord-webhook-notify@89b0bf43c2c8514f70d0dcba4a706b904e8a3112
+        with:
+          severity: info
+          description: ':watch: Scheduled Health check passed! :white_check_mark: '
+          details: 'Deployed web service is up and running'
+          text: '${{ github.event.repository.full_name }}: Health check'
+          webhookUrl: ${{ secrets.OMA_DISCORD_WEBHOOK }}
+      - name: Notify failed build and test action
+        if: ${{ failure() }}
+        uses: rjstone/discord-webhook-notify@89b0bf43c2c8514f70d0dcba4a706b904e8a3112
+        with:
+          severity: error
+          description: ':watch: Scheduled Health check failed! :x: '
+          details: 'Deployed web service does not seem to be online!'
+          text: '${{ github.event.repository.full_name }}: Health check'
+          webhookUrl: ${{ secrets.OMA_DISCORD_WEBHOOK }}

--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -13,3 +13,9 @@ jobs:
     steps:
       - name: 'Test output'
         run: echo "Testing the GitHub Action Schedule"
+      - name: Ping the deployed Pokédex health check url
+        uses: jtalk/url-health-check-action@f3f7bd79e4a64218eea7caad72796a1443896aeb
+        with:
+          url: ${{ vars.RENDER_DEPLOYED_URL }}/health
+          max-attempts: 5
+          retry-delay: 15s

--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -1,10 +1,7 @@
-name: Ping Pokedex Health Check
+name: Ping PokéDex Health Check
 
 on:
-  push:
-
   schedule:
-    - cron: '27,30,33 * * * *'
     - cron: '00,15,30,45 * * * *'
 
 jobs:

--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -1,0 +1,15 @@
+name: Ping Pokedex Health Check
+
+on:
+  push:
+
+  schedule:
+    - cron: '27,30,33 * * * *'
+    - cron: '00,15,30,45 * * * *'
+
+jobs:
+  test_schedule:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Test output'
+        run: echo "Testing the GitHub Action Schedule"

--- a/app.js
+++ b/app.js
@@ -5,7 +5,7 @@ const app = express()
 const PORT = process.env.PORT || 5000
 
 app.get('/version', (req, res) => {
-  res.send('1.0.17') // change to ensure new version deploy
+  res.send('1.0.18') // change to ensure new version deploy
 })
 
 app.get('/health', (req, res) => {

--- a/app.js
+++ b/app.js
@@ -5,7 +5,7 @@ const app = express()
 const PORT = process.env.PORT || 5000
 
 app.get('/version', (req, res) => {
-  res.send('1.0.16') // change to ensure new version deploy
+  res.send('1.0.17') // change to ensure new version deploy
 })
 
 app.get('/health', (req, res) => {


### PR DESCRIPTION
New GitHub Actions workflow to execute periodic scheduled health check on deployed web service.
The healtcheck actions is given some margin of error as the free tier render.com web service can take some time get up after been spinned down.

Current implementation sends notifications of result to private Discord channel and is scheduled to do the healtcheck every 15 minutes (00,15,30,45).