### PR TITLE
Use the render deploy action from its repo

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -122,8 +122,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: simple_deployment_pipeline
     steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/render-deploy
+      # - uses: actions/checkout@v3
+      # - uses: ./.github/actions/render-deploy
+      - uses: shamaanikala/use-render-deploy@8babc703db1abde0304a010c62cfdc1140298441
         with:
           render-service-id: ${{ secrets.RENDER_SERVICE_ID }}
           render-api-key: ${{ secrets.RENDER_API_KEY }}


### PR DESCRIPTION
Refactoring the workflow to use the own custom action from its own repository
[https://github.com/shamaanikala/use-render-deploy](https://github.com/shamaanikala/use-render-deploy)

The version `@v1-alpha` triggered an error within Visual Studio Code, so using the commit SHA.